### PR TITLE
Export location of headers files

### DIFF
--- a/blis-src/build.rs
+++ b/blis-src/build.rs
@@ -51,7 +51,8 @@ fn compile(blis_build: &Path, out_dir: &Path) {
             "aarch64" => "auto",       // cortexa57/thunderx2
             "powerpc64" => "auto",     // bgq/power9/power10
             _ => "generic",
-        }.to_string()
+        }
+        .to_string()
     };
     configure.arg(blis_confname);
     run(&mut configure);
@@ -73,7 +74,12 @@ fn main() {
             if build_dir.exists() {
                 fs::remove_dir_all(&build_dir).unwrap();
             }
-            if !std::fs::metadata("upstream").is_ok() {
+            // Check if upstream is a non-empty directory.
+            if std::fs::read_dir("upstream")
+                .ok()
+                .and_then(|mut d| d.next().filter(|de| de.is_ok()))
+                .is_none()
+            {
                 panic!("upstream directory can not be read. Consider running `git submodule update --init`.");
             }
             run(Command::new("cp").arg("-R").arg("upstream").arg(&build_dir));
@@ -83,6 +89,8 @@ fn main() {
             "cargo:rustc-link-search=native={}",
             lib_dir.to_string_lossy()
         );
+        let include_dir = out_dir.join("include");
+        println!("cargo:include={}", include_dir.to_string_lossy());
     }
     let kind = if env("CARGO_FEATURE_STATIC").is_some() {
         "static"


### PR DESCRIPTION
This makes it easier for dependents to access the BLIS headers.