### PR TITLE
Update BLIS and deps

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   macos:
-    runs-on: macos-13
+    runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:
@@ -30,7 +30,7 @@ jobs:
         --features=${{ matrix.feature }}
 
   linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
       image: rust
     strategy:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a Rust package to build and link [BLIS], the BLAS-like 
 
  ```toml
 [dependencies]
-blas-src = { version = "0.10", features = ["blis"] }
+blas-src = { version = "0.14", features = ["blis"] }
 ```
 
 To access the full BLIS API, direct use of `extern "C"` is necessary at this time.

--- a/blis-src/Cargo.toml
+++ b/blis-src/Cargo.toml
@@ -30,9 +30,9 @@ static = []
 system = []
 
 [dev-dependencies]
-libc = "0.2.154"
-blas-sys = "0.7"
-cblas-sys = "0.1.3"
+libc = "0.2.186"
+blas-sys = "0.9"
+cblas-sys = "0.3.0"
 
 [package.metadata.release]
 tag-name = "{{crate_name}}-{{version}}"


### PR DESCRIPTION
gcc-15 needs fixes for https://github.com/flame/blis/issues/846, which are not present in the BLIS-2.0 release.